### PR TITLE
fix: encode query parameters with encodeURIComponent

### DIFF
--- a/examples/proto/gen/typescript/einride/example/freight/v1/index.ts
+++ b/examples/proto/gen/typescript/einride/example/freight/v1/index.ts
@@ -372,15 +372,13 @@ export function createFreightServiceClient(
       }
       const path = `v1/${request.name}`; // eslint-disable-line quotes
       const body = null;
-      const query = new URLSearchParams();
-      let hasQuery = false; // eslint-disable-line prefer-const
+      const queryParams: string[] = [];
       if (request.name) {
-        hasQuery = true;
-        query.set("name", request.name.toString());
+        queryParams.push("name=" + encodeURIComponent(request.name.toString()));
       }
       let uri = path;
-      if (hasQuery) {
-        uri += "?" + query.toString();
+      if (queryParams.length > 0) {
+        uri += "?" + queryParams.join("&");
       }
       return handler({
         path: uri,
@@ -391,19 +389,16 @@ export function createFreightServiceClient(
     ListShippers(request) {
       const path = `v1/shippers`; // eslint-disable-line quotes
       const body = null;
-      const query = new URLSearchParams();
-      let hasQuery = false; // eslint-disable-line prefer-const
+      const queryParams: string[] = [];
       if (request.pageSize) {
-        hasQuery = true;
-        query.set("pageSize", request.pageSize.toString());
+        queryParams.push("pageSize=" + encodeURIComponent(request.pageSize.toString()));
       }
       if (request.pageToken) {
-        hasQuery = true;
-        query.set("pageToken", request.pageToken.toString());
+        queryParams.push("pageToken=" + encodeURIComponent(request.pageToken.toString()));
       }
       let uri = path;
-      if (hasQuery) {
-        uri += "?" + query.toString();
+      if (queryParams.length > 0) {
+        uri += "?" + queryParams.join("&");
       }
       return handler({
         path: uri,
@@ -414,11 +409,10 @@ export function createFreightServiceClient(
     CreateShipper(request) {
       const path = `v1/shippers`; // eslint-disable-line quotes
       const body = JSON.stringify(request?.shipper ?? {});
-      const query = new URLSearchParams();
-      let hasQuery = false; // eslint-disable-line prefer-const
+      const queryParams: string[] = [];
       let uri = path;
-      if (hasQuery) {
-        uri += "?" + query.toString();
+      if (queryParams.length > 0) {
+        uri += "?" + queryParams.join("&");
       }
       return handler({
         path: uri,
@@ -432,15 +426,13 @@ export function createFreightServiceClient(
       }
       const path = `v1/${request.shipper.name}`; // eslint-disable-line quotes
       const body = JSON.stringify(request?.shipper ?? {});
-      const query = new URLSearchParams();
-      let hasQuery = false; // eslint-disable-line prefer-const
+      const queryParams: string[] = [];
       if (request.updateMask) {
-        hasQuery = true;
-        query.set("updateMask", request.updateMask.toString());
+        queryParams.push("updateMask=" + encodeURIComponent(request.updateMask.toString()));
       }
       let uri = path;
-      if (hasQuery) {
-        uri += "?" + query.toString();
+      if (queryParams.length > 0) {
+        uri += "?" + queryParams.join("&");
       }
       return handler({
         path: uri,
@@ -454,15 +446,13 @@ export function createFreightServiceClient(
       }
       const path = `v1/${request.name}`; // eslint-disable-line quotes
       const body = null;
-      const query = new URLSearchParams();
-      let hasQuery = false; // eslint-disable-line prefer-const
+      const queryParams: string[] = [];
       if (request.name) {
-        hasQuery = true;
-        query.set("name", request.name.toString());
+        queryParams.push("name=" + encodeURIComponent(request.name.toString()));
       }
       let uri = path;
-      if (hasQuery) {
-        uri += "?" + query.toString();
+      if (queryParams.length > 0) {
+        uri += "?" + queryParams.join("&");
       }
       return handler({
         path: uri,
@@ -476,15 +466,13 @@ export function createFreightServiceClient(
       }
       const path = `v1/${request.name}`; // eslint-disable-line quotes
       const body = null;
-      const query = new URLSearchParams();
-      let hasQuery = false; // eslint-disable-line prefer-const
+      const queryParams: string[] = [];
       if (request.name) {
-        hasQuery = true;
-        query.set("name", request.name.toString());
+        queryParams.push("name=" + encodeURIComponent(request.name.toString()));
       }
       let uri = path;
-      if (hasQuery) {
-        uri += "?" + query.toString();
+      if (queryParams.length > 0) {
+        uri += "?" + queryParams.join("&");
       }
       return handler({
         path: uri,
@@ -498,23 +486,19 @@ export function createFreightServiceClient(
       }
       const path = `v1/${request.parent}/sites`; // eslint-disable-line quotes
       const body = null;
-      const query = new URLSearchParams();
-      let hasQuery = false; // eslint-disable-line prefer-const
+      const queryParams: string[] = [];
       if (request.parent) {
-        hasQuery = true;
-        query.set("parent", request.parent.toString());
+        queryParams.push("parent=" + encodeURIComponent(request.parent.toString()));
       }
       if (request.pageSize) {
-        hasQuery = true;
-        query.set("pageSize", request.pageSize.toString());
+        queryParams.push("pageSize=" + encodeURIComponent(request.pageSize.toString()));
       }
       if (request.pageToken) {
-        hasQuery = true;
-        query.set("pageToken", request.pageToken.toString());
+        queryParams.push("pageToken=" + encodeURIComponent(request.pageToken.toString()));
       }
       let uri = path;
-      if (hasQuery) {
-        uri += "?" + query.toString();
+      if (queryParams.length > 0) {
+        uri += "?" + queryParams.join("&");
       }
       return handler({
         path: uri,
@@ -528,15 +512,13 @@ export function createFreightServiceClient(
       }
       const path = `v1/${request.parent}/sites`; // eslint-disable-line quotes
       const body = JSON.stringify(request?.site ?? {});
-      const query = new URLSearchParams();
-      let hasQuery = false; // eslint-disable-line prefer-const
+      const queryParams: string[] = [];
       if (request.parent) {
-        hasQuery = true;
-        query.set("parent", request.parent.toString());
+        queryParams.push("parent=" + encodeURIComponent(request.parent.toString()));
       }
       let uri = path;
-      if (hasQuery) {
-        uri += "?" + query.toString();
+      if (queryParams.length > 0) {
+        uri += "?" + queryParams.join("&");
       }
       return handler({
         path: uri,
@@ -550,15 +532,13 @@ export function createFreightServiceClient(
       }
       const path = `v1/${request.site.name}`; // eslint-disable-line quotes
       const body = JSON.stringify(request?.site ?? {});
-      const query = new URLSearchParams();
-      let hasQuery = false; // eslint-disable-line prefer-const
+      const queryParams: string[] = [];
       if (request.updateMask) {
-        hasQuery = true;
-        query.set("updateMask", request.updateMask.toString());
+        queryParams.push("updateMask=" + encodeURIComponent(request.updateMask.toString()));
       }
       let uri = path;
-      if (hasQuery) {
-        uri += "?" + query.toString();
+      if (queryParams.length > 0) {
+        uri += "?" + queryParams.join("&");
       }
       return handler({
         path: uri,
@@ -572,15 +552,13 @@ export function createFreightServiceClient(
       }
       const path = `v1/${request.name}`; // eslint-disable-line quotes
       const body = null;
-      const query = new URLSearchParams();
-      let hasQuery = false; // eslint-disable-line prefer-const
+      const queryParams: string[] = [];
       if (request.name) {
-        hasQuery = true;
-        query.set("name", request.name.toString());
+        queryParams.push("name=" + encodeURIComponent(request.name.toString()));
       }
       let uri = path;
-      if (hasQuery) {
-        uri += "?" + query.toString();
+      if (queryParams.length > 0) {
+        uri += "?" + queryParams.join("&");
       }
       return handler({
         path: uri,
@@ -594,15 +572,13 @@ export function createFreightServiceClient(
       }
       const path = `v1/${request.name}`; // eslint-disable-line quotes
       const body = null;
-      const query = new URLSearchParams();
-      let hasQuery = false; // eslint-disable-line prefer-const
+      const queryParams: string[] = [];
       if (request.name) {
-        hasQuery = true;
-        query.set("name", request.name.toString());
+        queryParams.push("name=" + encodeURIComponent(request.name.toString()));
       }
       let uri = path;
-      if (hasQuery) {
-        uri += "?" + query.toString();
+      if (queryParams.length > 0) {
+        uri += "?" + queryParams.join("&");
       }
       return handler({
         path: uri,
@@ -616,23 +592,19 @@ export function createFreightServiceClient(
       }
       const path = `v1/${request.parent}/shipments`; // eslint-disable-line quotes
       const body = null;
-      const query = new URLSearchParams();
-      let hasQuery = false; // eslint-disable-line prefer-const
+      const queryParams: string[] = [];
       if (request.parent) {
-        hasQuery = true;
-        query.set("parent", request.parent.toString());
+        queryParams.push("parent=" + encodeURIComponent(request.parent.toString()));
       }
       if (request.pageSize) {
-        hasQuery = true;
-        query.set("pageSize", request.pageSize.toString());
+        queryParams.push("pageSize=" + encodeURIComponent(request.pageSize.toString()));
       }
       if (request.pageToken) {
-        hasQuery = true;
-        query.set("pageToken", request.pageToken.toString());
+        queryParams.push("pageToken=" + encodeURIComponent(request.pageToken.toString()));
       }
       let uri = path;
-      if (hasQuery) {
-        uri += "?" + query.toString();
+      if (queryParams.length > 0) {
+        uri += "?" + queryParams.join("&");
       }
       return handler({
         path: uri,
@@ -646,15 +618,13 @@ export function createFreightServiceClient(
       }
       const path = `v1/${request.parent}/shipments`; // eslint-disable-line quotes
       const body = JSON.stringify(request?.shipment ?? {});
-      const query = new URLSearchParams();
-      let hasQuery = false; // eslint-disable-line prefer-const
+      const queryParams: string[] = [];
       if (request.parent) {
-        hasQuery = true;
-        query.set("parent", request.parent.toString());
+        queryParams.push("parent=" + encodeURIComponent(request.parent.toString()));
       }
       let uri = path;
-      if (hasQuery) {
-        uri += "?" + query.toString();
+      if (queryParams.length > 0) {
+        uri += "?" + queryParams.join("&");
       }
       return handler({
         path: uri,
@@ -668,15 +638,13 @@ export function createFreightServiceClient(
       }
       const path = `v1/${request.shipment.name}`; // eslint-disable-line quotes
       const body = JSON.stringify(request?.shipment ?? {});
-      const query = new URLSearchParams();
-      let hasQuery = false; // eslint-disable-line prefer-const
+      const queryParams: string[] = [];
       if (request.updateMask) {
-        hasQuery = true;
-        query.set("updateMask", request.updateMask.toString());
+        queryParams.push("updateMask=" + encodeURIComponent(request.updateMask.toString()));
       }
       let uri = path;
-      if (hasQuery) {
-        uri += "?" + query.toString();
+      if (queryParams.length > 0) {
+        uri += "?" + queryParams.join("&");
       }
       return handler({
         path: uri,
@@ -690,15 +658,13 @@ export function createFreightServiceClient(
       }
       const path = `v1/${request.name}`; // eslint-disable-line quotes
       const body = null;
-      const query = new URLSearchParams();
-      let hasQuery = false; // eslint-disable-line prefer-const
+      const queryParams: string[] = [];
       if (request.name) {
-        hasQuery = true;
-        query.set("name", request.name.toString());
+        queryParams.push("name=" + encodeURIComponent(request.name.toString()));
       }
       let uri = path;
-      if (hasQuery) {
-        uri += "?" + query.toString();
+      if (queryParams.length > 0) {
+        uri += "?" + queryParams.join("&");
       }
       return handler({
         path: uri,

--- a/examples/proto/gen/typescript/einride/example/syntax/v1/index.ts
+++ b/examples/proto/gen/typescript/einride/example/syntax/v1/index.ts
@@ -279,25 +279,21 @@ export function createSyntaxServiceClient(
     QueryOnly(request) {
       const path = `v1`; // eslint-disable-line quotes
       const body = null;
-      const query = new URLSearchParams();
-      let hasQuery = false; // eslint-disable-line prefer-const
+      const queryParams: string[] = [];
       if (request.string) {
-        hasQuery = true;
-        query.set("string", request.string.toString());
+        queryParams.push("string=" + encodeURIComponent(request.string.toString()));
       }
       if (request.repeatedString) {
-        hasQuery = true;
         for (const x of request.repeatedString) {
-          query.append("repeatedString", x.toString());
+          queryParams.push("repeatedString=" + encodeURIComponent(x.toString()));
         }
       }
       if (request.nested?.string) {
-        hasQuery = true;
-        query.set("nested.string", request.nested.string.toString());
+        queryParams.push("nested.string=" + encodeURIComponent(request.nested.string.toString()));
       }
       let uri = path;
-      if (hasQuery) {
-        uri += "?" + query.toString();
+      if (queryParams.length > 0) {
+        uri += "?" + queryParams.join("&");
       }
       return handler({
         path: uri,
@@ -308,11 +304,10 @@ export function createSyntaxServiceClient(
     EmptyVerb(request) {
       const path = `v1:emptyVerb`; // eslint-disable-line quotes
       const body = null;
-      const query = new URLSearchParams();
-      let hasQuery = false; // eslint-disable-line prefer-const
+      const queryParams: string[] = [];
       let uri = path;
-      if (hasQuery) {
-        uri += "?" + query.toString();
+      if (queryParams.length > 0) {
+        uri += "?" + queryParams.join("&");
       }
       return handler({
         path: uri,
@@ -323,11 +318,10 @@ export function createSyntaxServiceClient(
     StarBody(request) {
       const path = `v1:starBody`; // eslint-disable-line quotes
       const body = JSON.stringify(request);
-      const query = new URLSearchParams();
-      const hasQuery = false;
+      const queryParams: string[] = [];
       let uri = path;
-      if (hasQuery) {
-        uri += "?" + query.toString();
+      if (queryParams.length > 0) {
+        uri += "?" + queryParams.join("&");
       }
       return handler({
         path: uri,
@@ -338,21 +332,18 @@ export function createSyntaxServiceClient(
     Body(request) {
       const path = `v1:body`; // eslint-disable-line quotes
       const body = JSON.stringify(request?.nested ?? {});
-      const query = new URLSearchParams();
-      let hasQuery = false; // eslint-disable-line prefer-const
+      const queryParams: string[] = [];
       if (request.string) {
-        hasQuery = true;
-        query.set("string", request.string.toString());
+        queryParams.push("string=" + encodeURIComponent(request.string.toString()));
       }
       if (request.repeatedString) {
-        hasQuery = true;
         for (const x of request.repeatedString) {
-          query.append("repeatedString", x.toString());
+          queryParams.push("repeatedString=" + encodeURIComponent(x.toString()));
         }
       }
       let uri = path;
-      if (hasQuery) {
-        uri += "?" + query.toString();
+      if (queryParams.length > 0) {
+        uri += "?" + queryParams.join("&");
       }
       return handler({
         path: uri,
@@ -366,25 +357,21 @@ export function createSyntaxServiceClient(
       }
       const path = `v1/${request.string}:path`; // eslint-disable-line quotes
       const body = null;
-      const query = new URLSearchParams();
-      let hasQuery = false; // eslint-disable-line prefer-const
+      const queryParams: string[] = [];
       if (request.string) {
-        hasQuery = true;
-        query.set("string", request.string.toString());
+        queryParams.push("string=" + encodeURIComponent(request.string.toString()));
       }
       if (request.repeatedString) {
-        hasQuery = true;
         for (const x of request.repeatedString) {
-          query.append("repeatedString", x.toString());
+          queryParams.push("repeatedString=" + encodeURIComponent(x.toString()));
         }
       }
       if (request.nested?.string) {
-        hasQuery = true;
-        query.set("nested.string", request.nested.string.toString());
+        queryParams.push("nested.string=" + encodeURIComponent(request.nested.string.toString()));
       }
       let uri = path;
-      if (hasQuery) {
-        uri += "?" + query.toString();
+      if (queryParams.length > 0) {
+        uri += "?" + queryParams.join("&");
       }
       return handler({
         path: uri,
@@ -398,21 +385,18 @@ export function createSyntaxServiceClient(
       }
       const path = `v1/${request.string}:pathBody`; // eslint-disable-line quotes
       const body = JSON.stringify(request?.nested ?? {});
-      const query = new URLSearchParams();
-      let hasQuery = false; // eslint-disable-line prefer-const
+      const queryParams: string[] = [];
       if (request.string) {
-        hasQuery = true;
-        query.set("string", request.string.toString());
+        queryParams.push("string=" + encodeURIComponent(request.string.toString()));
       }
       if (request.repeatedString) {
-        hasQuery = true;
         for (const x of request.repeatedString) {
-          query.append("repeatedString", x.toString());
+          queryParams.push("repeatedString=" + encodeURIComponent(x.toString()));
         }
       }
       let uri = path;
-      if (hasQuery) {
-        uri += "?" + query.toString();
+      if (queryParams.length > 0) {
+        uri += "?" + queryParams.join("&");
       }
       return handler({
         path: uri,

--- a/tools/eslint/.eslintrc.js
+++ b/tools/eslint/.eslintrc.js
@@ -2,5 +2,6 @@ module.exports = {
   extends: ["plugin:@einride/default"],
     rules: {
     "jest/no-deprecated-functions": 0,
+    "prettier/prettier": 0,
   },
 };


### PR DESCRIPTION
URLSearchParams encodes literal space (' ') as '+' which is according to
spec. However, some proxies, for example envoy does not currently
support decoding '+' to ' ', which means that spaces can not be sent as
query parameters.
