### PR TITLE
fix: ignore path covered fields in query parameters

### DIFF
--- a/examples/proto/gen/typescript/einride/example/freight/v1/index.ts
+++ b/examples/proto/gen/typescript/einride/example/freight/v1/index.ts
@@ -373,9 +373,6 @@ export function createFreightServiceClient(
       const path = `v1/${request.name}`; // eslint-disable-line quotes
       const body = null;
       const queryParams: string[] = [];
-      if (request.name) {
-        queryParams.push("name=" + encodeURIComponent(request.name.toString()));
-      }
       let uri = path;
       if (queryParams.length > 0) {
         uri += "?" + queryParams.join("&");
@@ -447,9 +444,6 @@ export function createFreightServiceClient(
       const path = `v1/${request.name}`; // eslint-disable-line quotes
       const body = null;
       const queryParams: string[] = [];
-      if (request.name) {
-        queryParams.push("name=" + encodeURIComponent(request.name.toString()));
-      }
       let uri = path;
       if (queryParams.length > 0) {
         uri += "?" + queryParams.join("&");
@@ -467,9 +461,6 @@ export function createFreightServiceClient(
       const path = `v1/${request.name}`; // eslint-disable-line quotes
       const body = null;
       const queryParams: string[] = [];
-      if (request.name) {
-        queryParams.push("name=" + encodeURIComponent(request.name.toString()));
-      }
       let uri = path;
       if (queryParams.length > 0) {
         uri += "?" + queryParams.join("&");
@@ -487,9 +478,6 @@ export function createFreightServiceClient(
       const path = `v1/${request.parent}/sites`; // eslint-disable-line quotes
       const body = null;
       const queryParams: string[] = [];
-      if (request.parent) {
-        queryParams.push("parent=" + encodeURIComponent(request.parent.toString()));
-      }
       if (request.pageSize) {
         queryParams.push("pageSize=" + encodeURIComponent(request.pageSize.toString()));
       }
@@ -513,9 +501,6 @@ export function createFreightServiceClient(
       const path = `v1/${request.parent}/sites`; // eslint-disable-line quotes
       const body = JSON.stringify(request?.site ?? {});
       const queryParams: string[] = [];
-      if (request.parent) {
-        queryParams.push("parent=" + encodeURIComponent(request.parent.toString()));
-      }
       let uri = path;
       if (queryParams.length > 0) {
         uri += "?" + queryParams.join("&");
@@ -553,9 +538,6 @@ export function createFreightServiceClient(
       const path = `v1/${request.name}`; // eslint-disable-line quotes
       const body = null;
       const queryParams: string[] = [];
-      if (request.name) {
-        queryParams.push("name=" + encodeURIComponent(request.name.toString()));
-      }
       let uri = path;
       if (queryParams.length > 0) {
         uri += "?" + queryParams.join("&");
@@ -573,9 +555,6 @@ export function createFreightServiceClient(
       const path = `v1/${request.name}`; // eslint-disable-line quotes
       const body = null;
       const queryParams: string[] = [];
-      if (request.name) {
-        queryParams.push("name=" + encodeURIComponent(request.name.toString()));
-      }
       let uri = path;
       if (queryParams.length > 0) {
         uri += "?" + queryParams.join("&");
@@ -593,9 +572,6 @@ export function createFreightServiceClient(
       const path = `v1/${request.parent}/shipments`; // eslint-disable-line quotes
       const body = null;
       const queryParams: string[] = [];
-      if (request.parent) {
-        queryParams.push("parent=" + encodeURIComponent(request.parent.toString()));
-      }
       if (request.pageSize) {
         queryParams.push("pageSize=" + encodeURIComponent(request.pageSize.toString()));
       }
@@ -619,9 +595,6 @@ export function createFreightServiceClient(
       const path = `v1/${request.parent}/shipments`; // eslint-disable-line quotes
       const body = JSON.stringify(request?.shipment ?? {});
       const queryParams: string[] = [];
-      if (request.parent) {
-        queryParams.push("parent=" + encodeURIComponent(request.parent.toString()));
-      }
       let uri = path;
       if (queryParams.length > 0) {
         uri += "?" + queryParams.join("&");
@@ -659,9 +632,6 @@ export function createFreightServiceClient(
       const path = `v1/${request.name}`; // eslint-disable-line quotes
       const body = null;
       const queryParams: string[] = [];
-      if (request.name) {
-        queryParams.push("name=" + encodeURIComponent(request.name.toString()));
-      }
       let uri = path;
       if (queryParams.length > 0) {
         uri += "?" + queryParams.join("&");

--- a/examples/proto/gen/typescript/einride/example/syntax/v1/index.ts
+++ b/examples/proto/gen/typescript/einride/example/syntax/v1/index.ts
@@ -358,9 +358,6 @@ export function createSyntaxServiceClient(
       const path = `v1/${request.string}:path`; // eslint-disable-line quotes
       const body = null;
       const queryParams: string[] = [];
-      if (request.string) {
-        queryParams.push("string=" + encodeURIComponent(request.string.toString()));
-      }
       if (request.repeatedString) {
         for (const x of request.repeatedString) {
           queryParams.push("repeatedString=" + encodeURIComponent(x.toString()));
@@ -386,9 +383,6 @@ export function createSyntaxServiceClient(
       const path = `v1/${request.string}:pathBody`; // eslint-disable-line quotes
       const body = JSON.stringify(request?.nested ?? {});
       const queryParams: string[] = [];
-      if (request.string) {
-        queryParams.push("string=" + encodeURIComponent(request.string.toString()));
-      }
       if (request.repeatedString) {
         for (const x of request.repeatedString) {
           queryParams.push("repeatedString=" + encodeURIComponent(x.toString()));

--- a/internal/plugin/servicegen.go
+++ b/internal/plugin/servicegen.go
@@ -183,6 +183,12 @@ func (s serviceGenerator) generateMethodQuery(
 	}
 	// fields covered by path
 	pathCovered := make(map[string]struct{})
+	for _, segment := range rule.Template.Segments {
+		if segment.Kind != httprule.SegmentKindVariable {
+			continue
+		}
+		pathCovered[segment.Variable.FieldPath.String()] = struct{}{}
+	}
 	walkJSONLeafFields(input, func(path httprule.FieldPath, field protoreflect.FieldDescriptor) {
 		if _, ok := pathCovered[path.String()]; ok {
 			return


### PR DESCRIPTION
This was the intention in the first place, but was forgotten about.
