### PR TITLE
feat: add protoc-insertion-point

### DIFF
--- a/examples/proto/gen/typescript/einride/example/freight/v1/index.ts
+++ b/examples/proto/gen/typescript/einride/example/freight/v1/index.ts
@@ -644,3 +644,5 @@ export function createFreightServiceClient(
     },
   };
 }
+
+// @@protoc_insertion_point(typescript-http-eof)

--- a/examples/proto/gen/typescript/einride/example/syntax/v1/index.ts
+++ b/examples/proto/gen/typescript/einride/example/syntax/v1/index.ts
@@ -400,3 +400,5 @@ export function createSyntaxServiceClient(
     },
   };
 }
+
+// @@protoc_insertion_point(typescript-http-eof)

--- a/examples/proto/gen/typescript/einride/example/syntax/v2/index.ts
+++ b/examples/proto/gen/typescript/einride/example/syntax/v2/index.ts
@@ -251,3 +251,5 @@ export type einrideexamplesyntaxv1_Message_NestedMessage = {
 export type einrideexamplesyntaxv1_Message_NestedEnum =
   // NESTEDENUM_UNSPECIFIED
   "NESTEDENUM_UNSPECIFIED";
+
+// @@protoc_insertion_point(typescript-http-eof)

--- a/internal/plugin/generate.go
+++ b/internal/plugin/generate.go
@@ -40,6 +40,8 @@ func Generate(request *pluginpb.CodeGeneratorRequest) (*pluginpb.CodeGeneratorRe
 		if err := (packageGenerator{pkg: pkg, files: files}).Generate(&index); err != nil {
 			return nil, fmt.Errorf("generate package '%s': %w", pkg, err)
 		}
+		index.P()
+		index.P("// @@protoc_insertion_point(typescript-http-eof)")
 		res.File = append(res.File, &pluginpb.CodeGeneratorResponse_File{
 			Name:    proto.String(path.Join(indexPathElems...)),
 			Content: proto.String(string(index.Content())),


### PR DESCRIPTION
In order for other plugins to generate extra code in the index.ts file
protoc_insertion_point can be used. This commit adds one insertion point
at the end of the file.

From docs:
> If non-empty, indicates that the named file should already exist, and the
> content here is to be inserted into that file at a defined insertion
> point.  This feature allows a code generator to extend the output
> produced by another code generator.  The original generator may provide
> insertion points by placing special annotations in the file that look
> like:
>   @@protoc_insertion_point(NAME)
