### PR TITLE
fix!: use type union instead of optional for fields

### DIFF
--- a/examples/proto/gen/typescript/einride/example/freight/v1/index.ts
+++ b/examples/proto/gen/typescript/einride/example/freight/v1/index.ts
@@ -6,32 +6,32 @@
 // [site][einride.example.freight.v1.Site].
 export type Shipment = {
   // The resource name of the shipment.
-  name?: string;
+  name: string | undefined;
   // The creation timestamp of the shipment.
-  createTime?: wellKnownTimestamp;
+  createTime: wellKnownTimestamp | undefined;
   // The last update timestamp of the shipment.
   // Updated when create/update/delete operation is shipment.
-  updateTime?: wellKnownTimestamp;
+  updateTime: wellKnownTimestamp | undefined;
   // The deletion timestamp of the shipment.
-  deleteTime?: wellKnownTimestamp;
+  deleteTime: wellKnownTimestamp | undefined;
   // The resource name of the origin site of the shipment.
   // Format: shippers/{shipper}/sites/{site}
-  originSite?: string;
+  originSite: string | undefined;
   // The resource name of the destination site of the shipment.
   // Format: shippers/{shipper}/sites/{site}
-  destinationSite?: string;
+  destinationSite: string | undefined;
   // The earliest pickup time of the shipment at the origin site.
-  pickupEarliestTime?: wellKnownTimestamp;
+  pickupEarliestTime: wellKnownTimestamp | undefined;
   // The latest pickup time of the shipment at the origin site.
-  pickupLatestTime?: wellKnownTimestamp;
+  pickupLatestTime: wellKnownTimestamp | undefined;
   // The earliest delivery time of the shipment at the destination site.
-  deliveryEarliestTime?: wellKnownTimestamp;
+  deliveryEarliestTime: wellKnownTimestamp | undefined;
   // The latest delivery time of the shipment at the destination site.
-  deliveryLatestTime?: wellKnownTimestamp;
+  deliveryLatestTime: wellKnownTimestamp | undefined;
   // The line items of the shipment.
-  lineItems?: LineItem[];
+  lineItems: LineItem[] | undefined;
   // Annotations of the shipment.
-  annotations?: { [key: string]: string };
+  annotations: { [key: string]: string } | undefined;
 };
 
 // Encoded using RFC 3339, where generated output will always be Z-normalized
@@ -42,46 +42,46 @@ type wellKnownTimestamp = string;
 // A shipment line item.
 export type LineItem = {
   // The title of the line item.
-  title?: string;
+  title: string | undefined;
   // The quantity of the line item.
-  quantity?: number;
+  quantity: number | undefined;
   // The weight of the line item in kilograms.
-  weightKg?: number;
+  weightKg: number | undefined;
   // The volume of the line item in cubic meters.
-  volumeM3?: number;
+  volumeM3: number | undefined;
 };
 
 // A shipper is a supplier or owner of goods to be transported.
 export type Shipper = {
   // The resource name of the shipper.
-  name?: string;
+  name: string | undefined;
   // The creation timestamp of the shipper.
-  createTime?: wellKnownTimestamp;
+  createTime: wellKnownTimestamp | undefined;
   // The last update timestamp of the shipper.
   // Updated when create/update/delete operation is performed.
-  updateTime?: wellKnownTimestamp;
+  updateTime: wellKnownTimestamp | undefined;
   // The deletion timestamp of the shipper.
-  deleteTime?: wellKnownTimestamp;
+  deleteTime: wellKnownTimestamp | undefined;
   // The display name of the shipper.
-  displayName?: string;
+  displayName: string | undefined;
 };
 
 // A site is a node in a [shipper][einride.example.freight.v1.Shipper]'s
 // transport network.
 export type Site = {
   // The resource name of the site.
-  name?: string;
+  name: string | undefined;
   // The creation timestamp of the site.
-  createTime?: wellKnownTimestamp;
+  createTime: wellKnownTimestamp | undefined;
   // The last update timestamp of the site.
   // Updated when create/update/delete operation is performed.
-  updateTime?: wellKnownTimestamp;
+  updateTime: wellKnownTimestamp | undefined;
   // The deletion timestamp of the site.
-  deleteTime?: wellKnownTimestamp;
+  deleteTime: wellKnownTimestamp | undefined;
   // The display name of the site.
-  displayName?: string;
+  displayName: string | undefined;
   // The geographic location of the site.
-  latLng?: googletype_LatLng;
+  latLng: googletype_LatLng | undefined;
 };
 
 // An object that represents a latitude/longitude pair. This is expressed as a
@@ -91,45 +91,45 @@ export type Site = {
 // standard</a>. Values must be within normalized ranges.
 export type googletype_LatLng = {
   // The latitude in degrees. It must be in the range [-90.0, +90.0].
-  latitude?: number;
+  latitude: number | undefined;
   // The longitude in degrees. It must be in the range [-180.0, +180.0].
-  longitude?: number;
+  longitude: number | undefined;
 };
 
 // Request message for FreightService.GetShipper.
 export type GetShipperRequest = {
   // The resource name of the shipper to retrieve.
   // Format: shippers/{shipper}
-  name?: string;
+  name: string | undefined;
 };
 
 // Request message for FreightService.ListShippers.
 export type ListShippersRequest = {
   // Requested page size. Server may return fewer shippers than requested.
   // If unspecified, server will pick an appropriate default.
-  pageSize?: number;
+  pageSize: number | undefined;
   // A token identifying a page of results the server should return.
   // Typically, this is the value of
   // [ListShippersResponse.next_page_token][einride.example.freight.v1.ListShippersResponse.next_page_token]
   // returned from the previous call to `ListShippers` method.
-  pageToken?: string;
+  pageToken: string | undefined;
 };
 
 // Response message for FreightService.ListShippers.
 export type ListShippersResponse = {
   // The list of shippers.
-  shippers?: Shipper[];
+  shippers: Shipper[] | undefined;
   // A token to retrieve next page of results.  Pass this value in the
   // [ListShippersRequest.page_token][einride.example.freight.v1.ListShippersRequest.page_token]
   // field in the subsequent call to `ListShippers` method to retrieve the next
   // page of results.
-  nextPageToken?: string;
+  nextPageToken: string | undefined;
 };
 
 // Request message for FreightService.CreateShipper.
 export type CreateShipperRequest = {
   // The shipper to create.
-  shipper?: Shipper;
+  shipper: Shipper | undefined;
 };
 
 // Request message for FreightService.UpdateShipper.
@@ -137,9 +137,9 @@ export type UpdateShipperRequest = {
   // The shipper to update with. The name must match or be empty.
   // The shipper's `name` field is used to identify the shipper to be updated.
   // Format: shippers/{shipper}
-  shipper?: Shipper;
+  shipper: Shipper | undefined;
   // The list of fields to be updated.
-  updateMask?: wellKnownFieldMask;
+  updateMask: wellKnownFieldMask | undefined;
 };
 
 // In JSON, a field mask is encoded as a single string where paths are
@@ -174,49 +174,49 @@ type wellKnownFieldMask = string;
 export type DeleteShipperRequest = {
   // The resource name of the shipper to delete.
   // Format: shippers/{shipper}
-  name?: string;
+  name: string | undefined;
 };
 
 // Request message for FreightService.GetSite.
 export type GetSiteRequest = {
   // The resource name of the site to retrieve.
   // Format: shippers/{shipper}/sites/{site}
-  name?: string;
+  name: string | undefined;
 };
 
 // Request message for FreightService.ListSites.
 export type ListSitesRequest = {
   // The resource name of the parent, which owns this collection of sites.
   // Format: shippers/{shipper}
-  parent?: string;
+  parent: string | undefined;
   // Requested page size. Server may return fewer sites than requested.
   // If unspecified, server will pick an appropriate default.
-  pageSize?: number;
+  pageSize: number | undefined;
   // A token identifying a page of results the server should return.
   // Typically, this is the value of
   // [ListSitesResponse.next_page_token][einride.example.freight.v1.ListSitesResponse.next_page_token]
   // returned from the previous call to `ListSites` method.
-  pageToken?: string;
+  pageToken: string | undefined;
 };
 
 // Response message for FreightService.ListSites.
 export type ListSitesResponse = {
   // The list of sites.
-  sites?: Site[];
+  sites: Site[] | undefined;
   // A token to retrieve next page of results.  Pass this value in the
   // [ListSitesRequest.page_token][einride.example.freight.v1.ListSitesRequest.page_token]
   // field in the subsequent call to `ListSites` method to retrieve the next
   // page of results.
-  nextPageToken?: string;
+  nextPageToken: string | undefined;
 };
 
 // Request message for FreightService.CreateSite.
 export type CreateSiteRequest = {
   // The resource name of the parent shipper for which this site will be created.
   // Format: shippers/{shipper}
-  parent?: string;
+  parent: string | undefined;
   // The site to create.
-  site?: Site;
+  site: Site | undefined;
 };
 
 // Request message for FreightService.UpdateSite.
@@ -224,58 +224,58 @@ export type UpdateSiteRequest = {
   // The site to update with. The name must match or be empty.
   // The site's `name` field is used to identify the site to be updated.
   // Format: shippers/{shipper}/sites/{site}
-  site?: Site;
+  site: Site | undefined;
   // The list of fields to be updated.
-  updateMask?: wellKnownFieldMask;
+  updateMask: wellKnownFieldMask | undefined;
 };
 
 // Request message for FreightService.DeleteSite.
 export type DeleteSiteRequest = {
   // The resource name of the site to delete.
   // Format: shippers/{shipper}/sites/{site}
-  name?: string;
+  name: string | undefined;
 };
 
 // Request message for FreightService.GetShipment.
 export type GetShipmentRequest = {
   // The resource name of the shipment to retrieve.
   // Format: shippers/{shipper}/shipments/{shipment}
-  name?: string;
+  name: string | undefined;
 };
 
 // Request message for FreightService.ListShipments.
 export type ListShipmentsRequest = {
   // The resource name of the parent, which owns this collection of shipments.
   // Format: shippers/{shipper}
-  parent?: string;
+  parent: string | undefined;
   // Requested page size. Server may return fewer shipments than requested.
   // If unspecified, server will pick an appropriate default.
-  pageSize?: number;
+  pageSize: number | undefined;
   // A token identifying a page of results the server should return.
   // Typically, this is the value of
   // [ListShipmentsResponse.next_page_token][einride.example.freight.v1.ListShipmentsResponse.next_page_token]
   // returned from the previous call to `ListShipments` method.
-  pageToken?: string;
+  pageToken: string | undefined;
 };
 
 // Response message for FreightService.ListShipments.
 export type ListShipmentsResponse = {
   // The list of shipments.
-  shipments?: Shipment[];
+  shipments: Shipment[] | undefined;
   // A token to retrieve next page of results.  Pass this value in the
   // [ListShipmentsRequest.page_token][einride.example.freight.v1.ListShipmentsRequest.page_token]
   // field in the subsequent call to `ListShipments` method to retrieve the next
   // page of results.
-  nextPageToken?: string;
+  nextPageToken: string | undefined;
 };
 
 // Request message for FreightService.CreateShipment.
 export type CreateShipmentRequest = {
   // The resource name of the parent shipper for which this shipment will be created.
   // Format: shippers/{shipper}
-  parent?: string;
+  parent: string | undefined;
   // The shipment to create.
-  shipment?: Shipment;
+  shipment: Shipment | undefined;
 };
 
 // Request message for FreightService.UpdateShipment.
@@ -283,16 +283,16 @@ export type UpdateShipmentRequest = {
   // The shipment to update with. The name must match or be empty.
   // The shipment's `name` field is used to identify the shipment to be updated.
   // Format: shippers/{shipper}/shipments/{shipment}
-  shipment?: Shipment;
+  shipment: Shipment | undefined;
   // The list of fields to be updated.
-  updateMask?: wellKnownFieldMask;
+  updateMask: wellKnownFieldMask | undefined;
 };
 
 // Request message for FreightService.DeleteShipment.
 export type DeleteShipmentRequest = {
   // The resource name of the shipment to delete.
   // Format: shippers/{shipper}/shipments/{shipment}
-  name?: string;
+  name: string | undefined;
 };
 
 // This API represents a simple freight service.

--- a/examples/proto/gen/typescript/einride/example/syntax/v1/index.ts
+++ b/examples/proto/gen/typescript/einride/example/syntax/v1/index.ts
@@ -12,77 +12,77 @@ export type Enum =
 // Message
 export type Message = {
   // double
-  double?: number;
+  double: number | undefined;
   // float
-  float?: number;
+  float: number | undefined;
   // int32
-  int32?: number;
+  int32: number | undefined;
   // int64
-  int64?: number;
+  int64: number | undefined;
   // uint32
-  uint32?: number;
+  uint32: number | undefined;
   // uint64
-  uint64?: number;
+  uint64: number | undefined;
   // sint32
-  sint32?: number;
+  sint32: number | undefined;
   // sint64
-  sint64?: number;
+  sint64: number | undefined;
   // fixed32
-  fixed32?: number;
+  fixed32: number | undefined;
   // fixed64
-  fixed64?: number;
+  fixed64: number | undefined;
   // sfixed32
-  sfixed32?: number;
+  sfixed32: number | undefined;
   // sfixed64
-  sfixed64?: number;
+  sfixed64: number | undefined;
   // bool
-  bool?: boolean;
+  bool: boolean | undefined;
   // string
-  string?: string;
+  string: string | undefined;
   // bytes
-  bytes?: string;
+  bytes: string | undefined;
   // enum
-  enum?: Enum;
+  enum: Enum | undefined;
   // message
-  message?: Message;
+  message: Message | undefined;
   // repeated_double
-  repeatedDouble?: number[];
+  repeatedDouble: number[] | undefined;
   // repeated_float
-  repeatedFloat?: number[];
+  repeatedFloat: number[] | undefined;
   // repeated_int32
-  repeatedInt32?: number[];
+  repeatedInt32: number[] | undefined;
   // repeated_int64
-  repeatedInt64?: number[];
+  repeatedInt64: number[] | undefined;
   // repeated_uint32
-  repeatedUint32?: number[];
+  repeatedUint32: number[] | undefined;
   // repeated_uint64
-  repeatedUint64?: number[];
+  repeatedUint64: number[] | undefined;
   // repeated_sint32
-  repeatedSint32?: number[];
+  repeatedSint32: number[] | undefined;
   // repeated_sint64
-  repeatedSint64?: number[];
+  repeatedSint64: number[] | undefined;
   // repeated_fixed32
-  repeatedFixed32?: number[];
+  repeatedFixed32: number[] | undefined;
   // repeated_fixed64
-  repeatedFixed64?: number[];
+  repeatedFixed64: number[] | undefined;
   // repeated_sfixed32
-  repeatedSfixed32?: number[];
+  repeatedSfixed32: number[] | undefined;
   // repeated_sfixed64
-  repeatedSfixed64?: number[];
+  repeatedSfixed64: number[] | undefined;
   // repeated_bool
-  repeatedBool?: boolean[];
+  repeatedBool: boolean[] | undefined;
   // repeated_string
-  repeatedString?: string[];
+  repeatedString: string[] | undefined;
   // repeated_bytes
-  repeatedBytes?: string[];
+  repeatedBytes: string[] | undefined;
   // repeated_enum
-  repeatedEnum?: Enum[];
+  repeatedEnum: Enum[] | undefined;
   // repeated_message
-  repeatedMessage?: Message[];
+  repeatedMessage: Message[] | undefined;
   // map_string_string
-  mapStringString?: { [key: string]: string };
+  mapStringString: { [key: string]: string } | undefined;
   // map_string_message
-  mapStringMessage?: { [key: string]: Message };
+  mapStringMessage: { [key: string]: Message } | undefined;
   // oneof_string
   oneofString?: string;
   // oneof_enum
@@ -92,73 +92,73 @@ export type Message = {
   // oneof_message2
   oneofMessage2?: Message;
   // any
-  any?: wellKnownAny;
+  any: wellKnownAny | undefined;
   // repeated_any
-  repeatedAny?: wellKnownAny[];
+  repeatedAny: wellKnownAny[] | undefined;
   // duration
-  duration?: wellKnownDuration;
+  duration: wellKnownDuration | undefined;
   // repeated_duration
-  repeatedDuration?: wellKnownDuration[];
+  repeatedDuration: wellKnownDuration[] | undefined;
   // empty
-  empty?: wellKnownEmpty;
+  empty: wellKnownEmpty | undefined;
   // repeated_empty
-  repeatedEmpty?: wellKnownEmpty[];
+  repeatedEmpty: wellKnownEmpty[] | undefined;
   // field_mask
-  fieldMask?: wellKnownFieldMask;
+  fieldMask: wellKnownFieldMask | undefined;
   // repeated_field_mask
-  repeatedFieldMask?: wellKnownFieldMask[];
+  repeatedFieldMask: wellKnownFieldMask[] | undefined;
   // struct
-  struct?: wellKnownStruct;
+  struct: wellKnownStruct | undefined;
   // repeated_struct
-  repeatedStruct?: wellKnownStruct[];
+  repeatedStruct: wellKnownStruct[] | undefined;
   // value
-  value?: wellKnownValue;
+  value: wellKnownValue | undefined;
   // repeated_value
-  repeatedValue?: wellKnownValue[];
+  repeatedValue: wellKnownValue[] | undefined;
   // null_value
-  nullValue?: wellKnownNullValue;
+  nullValue: wellKnownNullValue | undefined;
   // repeated_null_value
-  repeatedNullValue?: wellKnownNullValue[];
+  repeatedNullValue: wellKnownNullValue[] | undefined;
   // list_value
-  listValue?: wellKnownListValue;
+  listValue: wellKnownListValue | undefined;
   // repeated_list_value
-  repeatedListValue?: wellKnownListValue[];
+  repeatedListValue: wellKnownListValue[] | undefined;
   // bool_value
-  boolValue?: wellKnownBoolValue;
+  boolValue: wellKnownBoolValue | undefined;
   // repeated_bool_value
-  repeatedBoolValue?: wellKnownBoolValue[];
+  repeatedBoolValue: wellKnownBoolValue[] | undefined;
   // bytes_value
-  bytesValue?: wellKnownBytesValue;
+  bytesValue: wellKnownBytesValue | undefined;
   // repeated_bytes_value
-  repeatedBytesValue?: wellKnownBytesValue[];
+  repeatedBytesValue: wellKnownBytesValue[] | undefined;
   // double_value
-  doubleValue?: wellKnownDoubleValue;
+  doubleValue: wellKnownDoubleValue | undefined;
   // repeated_double_value
-  repeatedDoubleValue?: wellKnownDoubleValue[];
+  repeatedDoubleValue: wellKnownDoubleValue[] | undefined;
   // float_value
-  floatValue?: wellKnownFloatValue;
+  floatValue: wellKnownFloatValue | undefined;
   // repeated_float_value
-  repeatedFloatValue?: wellKnownFloatValue[];
+  repeatedFloatValue: wellKnownFloatValue[] | undefined;
   // int32_value
-  int32Value?: wellKnownInt32Value;
+  int32Value: wellKnownInt32Value | undefined;
   // repeated_int32_value
-  repeatedInt32Value?: wellKnownInt32Value[];
+  repeatedInt32Value: wellKnownInt32Value[] | undefined;
   // int64_value
-  int64Value?: wellKnownInt64Value;
+  int64Value: wellKnownInt64Value | undefined;
   // repeated_int64_value
-  repeatedInt64Value?: wellKnownInt64Value[];
+  repeatedInt64Value: wellKnownInt64Value[] | undefined;
   // uint32_value
-  uint32Value?: wellKnownUInt32Value;
+  uint32Value: wellKnownUInt32Value | undefined;
   // repeated_uint32_value
-  repeatedUint32Value?: wellKnownUInt32Value[];
+  repeatedUint32Value: wellKnownUInt32Value[] | undefined;
   // uint64_value
-  uint64Value?: wellKnownUInt64Value;
+  uint64Value: wellKnownUInt64Value | undefined;
   // repeated_uint64_value
-  repeatedUint64Value?: wellKnownUInt64Value[];
+  repeatedUint64Value: wellKnownUInt64Value[] | undefined;
   // string_value
-  stringValue?: wellKnownUInt64Value;
+  stringValue: wellKnownUInt64Value | undefined;
   // repeated_string_value
-  repeatedStringValue?: wellKnownStringValue[];
+  repeatedStringValue: wellKnownStringValue[] | undefined;
 };
 
 // If the Any contains a value that has a special JSON mapping,
@@ -238,7 +238,7 @@ type wellKnownStringValue = string | null;
 // NestedMessage
 export type Message_NestedMessage = {
   // nested_message.string
-  string?: string;
+  string: string | undefined;
 };
 
 // NestedEnum
@@ -246,13 +246,13 @@ export type Message_NestedEnum =
   // NESTEDENUM_UNSPECIFIED
   "NESTEDENUM_UNSPECIFIED";
 export type Request = {
-  string?: string;
-  repeatedString?: string[];
-  nested?: Request_Nested;
+  string: string | undefined;
+  repeatedString: string[] | undefined;
+  nested: Request_Nested | undefined;
 };
 
 export type Request_Nested = {
-  string?: string;
+  string: string | undefined;
 };
 
 export interface SyntaxService {

--- a/examples/proto/gen/typescript/einride/example/syntax/v2/index.ts
+++ b/examples/proto/gen/typescript/einride/example/syntax/v2/index.ts
@@ -3,84 +3,84 @@
 
 // Message
 export type Message = {
-  forwardedMessage?: einrideexamplesyntaxv1_Message;
-  forwardedEnum?: einrideexamplesyntaxv1_Enum;
+  forwardedMessage: einrideexamplesyntaxv1_Message | undefined;
+  forwardedEnum: einrideexamplesyntaxv1_Enum | undefined;
 };
 
 // Message
 export type einrideexamplesyntaxv1_Message = {
   // double
-  double?: number;
+  double: number | undefined;
   // float
-  float?: number;
+  float: number | undefined;
   // int32
-  int32?: number;
+  int32: number | undefined;
   // int64
-  int64?: number;
+  int64: number | undefined;
   // uint32
-  uint32?: number;
+  uint32: number | undefined;
   // uint64
-  uint64?: number;
+  uint64: number | undefined;
   // sint32
-  sint32?: number;
+  sint32: number | undefined;
   // sint64
-  sint64?: number;
+  sint64: number | undefined;
   // fixed32
-  fixed32?: number;
+  fixed32: number | undefined;
   // fixed64
-  fixed64?: number;
+  fixed64: number | undefined;
   // sfixed32
-  sfixed32?: number;
+  sfixed32: number | undefined;
   // sfixed64
-  sfixed64?: number;
+  sfixed64: number | undefined;
   // bool
-  bool?: boolean;
+  bool: boolean | undefined;
   // string
-  string?: string;
+  string: string | undefined;
   // bytes
-  bytes?: string;
+  bytes: string | undefined;
   // enum
-  enum?: einrideexamplesyntaxv1_Enum;
+  enum: einrideexamplesyntaxv1_Enum | undefined;
   // message
-  message?: einrideexamplesyntaxv1_Message;
+  message: einrideexamplesyntaxv1_Message | undefined;
   // repeated_double
-  repeatedDouble?: number[];
+  repeatedDouble: number[] | undefined;
   // repeated_float
-  repeatedFloat?: number[];
+  repeatedFloat: number[] | undefined;
   // repeated_int32
-  repeatedInt32?: number[];
+  repeatedInt32: number[] | undefined;
   // repeated_int64
-  repeatedInt64?: number[];
+  repeatedInt64: number[] | undefined;
   // repeated_uint32
-  repeatedUint32?: number[];
+  repeatedUint32: number[] | undefined;
   // repeated_uint64
-  repeatedUint64?: number[];
+  repeatedUint64: number[] | undefined;
   // repeated_sint32
-  repeatedSint32?: number[];
+  repeatedSint32: number[] | undefined;
   // repeated_sint64
-  repeatedSint64?: number[];
+  repeatedSint64: number[] | undefined;
   // repeated_fixed32
-  repeatedFixed32?: number[];
+  repeatedFixed32: number[] | undefined;
   // repeated_fixed64
-  repeatedFixed64?: number[];
+  repeatedFixed64: number[] | undefined;
   // repeated_sfixed32
-  repeatedSfixed32?: number[];
+  repeatedSfixed32: number[] | undefined;
   // repeated_sfixed64
-  repeatedSfixed64?: number[];
+  repeatedSfixed64: number[] | undefined;
   // repeated_bool
-  repeatedBool?: boolean[];
+  repeatedBool: boolean[] | undefined;
   // repeated_string
-  repeatedString?: string[];
+  repeatedString: string[] | undefined;
   // repeated_bytes
-  repeatedBytes?: string[];
+  repeatedBytes: string[] | undefined;
   // repeated_enum
-  repeatedEnum?: einrideexamplesyntaxv1_Enum[];
+  repeatedEnum: einrideexamplesyntaxv1_Enum[] | undefined;
   // repeated_message
-  repeatedMessage?: einrideexamplesyntaxv1_Message[];
+  repeatedMessage: einrideexamplesyntaxv1_Message[] | undefined;
   // map_string_string
-  mapStringString?: { [key: string]: string };
+  mapStringString: { [key: string]: string } | undefined;
   // map_string_message
-  mapStringMessage?: { [key: string]: einrideexamplesyntaxv1_Message };
+  mapStringMessage: { [key: string]: einrideexamplesyntaxv1_Message } | undefined;
   // oneof_string
   oneofString?: string;
   // oneof_enum
@@ -90,73 +90,73 @@ export type einrideexamplesyntaxv1_Message = {
   // oneof_message2
   oneofMessage2?: einrideexamplesyntaxv1_Message;
   // any
-  any?: wellKnownAny;
+  any: wellKnownAny | undefined;
   // repeated_any
-  repeatedAny?: wellKnownAny[];
+  repeatedAny: wellKnownAny[] | undefined;
   // duration
-  duration?: wellKnownDuration;
+  duration: wellKnownDuration | undefined;
   // repeated_duration
-  repeatedDuration?: wellKnownDuration[];
+  repeatedDuration: wellKnownDuration[] | undefined;
   // empty
-  empty?: wellKnownEmpty;
+  empty: wellKnownEmpty | undefined;
   // repeated_empty
-  repeatedEmpty?: wellKnownEmpty[];
+  repeatedEmpty: wellKnownEmpty[] | undefined;
   // field_mask
-  fieldMask?: wellKnownFieldMask;
+  fieldMask: wellKnownFieldMask | undefined;
   // repeated_field_mask
-  repeatedFieldMask?: wellKnownFieldMask[];
+  repeatedFieldMask: wellKnownFieldMask[] | undefined;
   // struct
-  struct?: wellKnownStruct;
+  struct: wellKnownStruct | undefined;
   // repeated_struct
-  repeatedStruct?: wellKnownStruct[];
+  repeatedStruct: wellKnownStruct[] | undefined;
   // value
-  value?: wellKnownValue;
+  value: wellKnownValue | undefined;
   // repeated_value
-  repeatedValue?: wellKnownValue[];
+  repeatedValue: wellKnownValue[] | undefined;
   // null_value
-  nullValue?: wellKnownNullValue;
+  nullValue: wellKnownNullValue | undefined;
   // repeated_null_value
-  repeatedNullValue?: wellKnownNullValue[];
+  repeatedNullValue: wellKnownNullValue[] | undefined;
   // list_value
-  listValue?: wellKnownListValue;
+  listValue: wellKnownListValue | undefined;
   // repeated_list_value
-  repeatedListValue?: wellKnownListValue[];
+  repeatedListValue: wellKnownListValue[] | undefined;
   // bool_value
-  boolValue?: wellKnownBoolValue;
+  boolValue: wellKnownBoolValue | undefined;
   // repeated_bool_value
-  repeatedBoolValue?: wellKnownBoolValue[];
+  repeatedBoolValue: wellKnownBoolValue[] | undefined;
   // bytes_value
-  bytesValue?: wellKnownBytesValue;
+  bytesValue: wellKnownBytesValue | undefined;
   // repeated_bytes_value
-  repeatedBytesValue?: wellKnownBytesValue[];
+  repeatedBytesValue: wellKnownBytesValue[] | undefined;
   // double_value
-  doubleValue?: wellKnownDoubleValue;
+  doubleValue: wellKnownDoubleValue | undefined;
   // repeated_double_value
-  repeatedDoubleValue?: wellKnownDoubleValue[];
+  repeatedDoubleValue: wellKnownDoubleValue[] | undefined;
   // float_value
-  floatValue?: wellKnownFloatValue;
+  floatValue: wellKnownFloatValue | undefined;
   // repeated_float_value
-  repeatedFloatValue?: wellKnownFloatValue[];
+  repeatedFloatValue: wellKnownFloatValue[] | undefined;
   // int32_value
-  int32Value?: wellKnownInt32Value;
+  int32Value: wellKnownInt32Value | undefined;
   // repeated_int32_value
-  repeatedInt32Value?: wellKnownInt32Value[];
+  repeatedInt32Value: wellKnownInt32Value[] | undefined;
   // int64_value
-  int64Value?: wellKnownInt64Value;
+  int64Value: wellKnownInt64Value | undefined;
   // repeated_int64_value
-  repeatedInt64Value?: wellKnownInt64Value[];
+  repeatedInt64Value: wellKnownInt64Value[] | undefined;
   // uint32_value
-  uint32Value?: wellKnownUInt32Value;
+  uint32Value: wellKnownUInt32Value | undefined;
   // repeated_uint32_value
-  repeatedUint32Value?: wellKnownUInt32Value[];
+  repeatedUint32Value: wellKnownUInt32Value[] | undefined;
   // uint64_value
-  uint64Value?: wellKnownUInt64Value;
+  uint64Value: wellKnownUInt64Value | undefined;
   // repeated_uint64_value
-  repeatedUint64Value?: wellKnownUInt64Value[];
+  repeatedUint64Value: wellKnownUInt64Value[] | undefined;
   // string_value
-  stringValue?: wellKnownUInt64Value;
+  stringValue: wellKnownUInt64Value | undefined;
   // repeated_string_value
-  repeatedStringValue?: wellKnownStringValue[];
+  repeatedStringValue: wellKnownStringValue[] | undefined;
 };
 
 // Enum
@@ -244,7 +244,7 @@ type wellKnownStringValue = string | null;
 // NestedMessage
 export type einrideexamplesyntaxv1_Message_NestedMessage = {
   // nested_message.string
-  string?: string;
+  string: string | undefined;
 };
 
 // NestedEnum

--- a/internal/plugin/messagegen.go
+++ b/internal/plugin/messagegen.go
@@ -16,8 +16,13 @@ func (m messageGenerator) Generate(f *codegen.File) {
 	rangeFields(m.message, func(field protoreflect.FieldDescriptor) {
 		commentGenerator{descriptor: field}.generateLeading(f, 1)
 		fieldType := typeFromField(m.pkg, field)
-		f.P(t(1), field.JSONName(), "?: ", fieldType.Reference(), ";")
+		if field.ContainingOneof() == nil {
+			f.P(t(1), field.JSONName(), ": ", fieldType.Reference(), " | undefined;")
+		} else {
+			f.P(t(1), field.JSONName(), "?: ", fieldType.Reference(), ";")
+		}
 	})
+
 	f.P("};")
 	f.P()
 }


### PR DESCRIPTION
Changes how nullability is expressed in the generated types.

Previously every field was optional
```ts
type Message = {
  field?: string;
}
```
which is convenient as there is no need to specify every field that
exists in the message when declaring it.

However this have some unfortunate side effects, most notably that
almost every type is assignable to other types.

```ts
type MessageA = {
  foo?: string;
}

type MessageB = {
  bar?: string;
}

const a: MessageA = {}
const b: MessageB = a; // ok because no field needs to be set in
MessageB.
```

This can lead to subtle bugs when passing these types around.

With this change every field is no longer optional, but `undefined` is a
valid value for every field.
```ts
type MessageA = {
  field: string | undefined;
}
```

Fields belonging to a oneof is still typed as optional, because only one
of these fields should ever be set.

```ts
type MessageA = {
  foo: string | undefined;
}

type MessageB = {
  bar: string | undefined;
}

const a: MessageA = { foo: undefined };
const b: MessageB = a; // error
```

---

BREAKING CHANGE: Fields that could previously be omitted when declaring
a variable, now needs to explicitly be set to `undefined`. Code that
reads these fields will not break.
