### PR TITLE
feat: add generator for default service configuration

### DIFF
--- a/examples/proto/buf.lock
+++ b/examples/proto/buf.lock
@@ -2,9 +2,10 @@
 version: v1
 deps:
   - remote: buf.build
+    owner: einride
+    repository: grpc-service-config
+    commit: f9bc1b4483044934863ba651a406f5a6
+  - remote: buf.build
     owner: googleapis
     repository: googleapis
-    branch: main
-    commit: 9088184d3ed04821b7e990024ff05656
-    digest: b1---R9Xre3yvH8peoJPQ0dsUYp37KzdlBlx5fjPsYekyI=
-    create_time: 2021-12-23T15:04:49.66847Z
+    commit: 8d7204855ec14631a499bd7393ce1970

--- a/examples/proto/buf.yaml
+++ b/examples/proto/buf.yaml
@@ -4,6 +4,7 @@ name: buf.build/einride/protoc-gen-typescript-http
 
 deps:
   - buf.build/googleapis/googleapis
+  - buf.build/einride/grpc-service-config
 
 lint:
   use:

--- a/examples/proto/einride/example/freight/v1/default_service_config.proto
+++ b/examples/proto/einride/example/freight/v1/default_service_config.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+
+package einride.example.freight.v1;
+
+import "einride/serviceconfig/v1/annotations.proto";
+
+option (einride.serviceconfig.v1.default_service_config) = {
+  method_config: {
+    name: {}
+    timeout: {
+      seconds: 10
+    }
+    retry_policy: {
+      initial_backoff: {
+        nanos: 200000000 // 0.2s
+      }
+      max_backoff: {
+        seconds: 60
+      }
+      max_attempts: 5
+      backoff_multiplier: 2
+      retryable_status_codes: UNAVAILABLE
+      retryable_status_codes: UNKNOWN
+    }
+  }
+};

--- a/examples/proto/gen/typescript/einride/example/freight/v1/index.ts
+++ b/examples/proto/gen/typescript/einride/example/freight/v1/index.ts
@@ -710,5 +710,6 @@ export function createFreightServiceClient(
     },
   };
 }
+export const defaultServiceConfiguration = {"methodConfig":[{"name":[{}],"timeout":"10s","retryPolicy":{"maxAttempts":5,"initialBackoff":"0.200s","maxBackoff":"60s","backoffMultiplier":2,"retryableStatusCodes":["UNAVAILABLE","UNKNOWN"]}}]}
 
 // @@protoc_insertion_point(typescript-http-eof)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module go.einride.tech/protoc-gen-typescript-http
 go 1.17
 
 require (
+	go.buf.build/protocolbuffers/go/einride/grpc-service-config v1.3.3
 	google.golang.org/genproto v0.0.0-20201214200347-8c77b98c765d
 	google.golang.org/protobuf v1.28.1
 	gotest.tools/v3 v3.3.0

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+go.buf.build/protocolbuffers/go/einride/grpc-service-config v1.3.3 h1:o7VOQ1GUysSVbhxrAUqmqTSuVPoHY1uYkx88VIDfEZ8=
+go.buf.build/protocolbuffers/go/einride/grpc-service-config v1.3.3/go.mod h1:6IB/7iOFF7EYvb0kxe2a8AWjVqIsxFbJqgdAGOUX3uA=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/internal/plugin/generate.go
+++ b/internal/plugin/generate.go
@@ -40,6 +40,9 @@ func Generate(request *pluginpb.CodeGeneratorRequest) (*pluginpb.CodeGeneratorRe
 		if err := (packageGenerator{pkg: pkg, files: files}).Generate(&index); err != nil {
 			return nil, fmt.Errorf("generate package '%s': %w", pkg, err)
 		}
+		if err := (serviceConfigGenerator{pkg: pkg, files: files}).Generate(&index); err != nil {
+			return nil, fmt.Errorf("generate default service config '%s': %w", pkg, err)
+		}
 		index.P()
 		index.P("// @@protoc_insertion_point(typescript-http-eof)")
 		res.File = append(res.File, &pluginpb.CodeGeneratorResponse_File{

--- a/internal/plugin/serviceconfiggen.go
+++ b/internal/plugin/serviceconfiggen.go
@@ -1,0 +1,40 @@
+package plugin
+
+import (
+	serviceconfigv1 "go.buf.build/protocolbuffers/go/einride/grpc-service-config/einride/serviceconfig/v1"
+	"go.einride.tech/protoc-gen-typescript-http/internal/codegen"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+type serviceConfigGenerator struct {
+	pkg   protoreflect.FullName
+	files []protoreflect.FileDescriptor
+}
+
+func (sc serviceConfigGenerator) Generate(f *codegen.File) error {
+	seen := false
+	for _, file := range sc.files {
+		defaultServiceConfig := proto.GetExtension(
+			file.Options(),
+			serviceconfigv1.E_DefaultServiceConfig,
+		).(*serviceconfigv1.ServiceConfig)
+		if defaultServiceConfig == nil {
+			continue
+		}
+		if seen {
+			continue
+		}
+		seen = true
+
+		json, err := protojson.Marshal(defaultServiceConfig)
+		if err != nil {
+			return err
+		}
+
+		f.P("export const defaultServiceConfiguration = ", string(json))
+	}
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -19,7 +19,7 @@ func main() {
 }
 
 func run() error {
-	in, err := ioutil.ReadAll(os.Stdin)
+	in, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adding generation for the default service configuration, for frontends to use when implementing retry strategies.