### PR TITLE
fix: add .semrel to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea
 tools/*/*/
 bin
+.semrel
+.generated-go-semantic-release-changelog.md


### PR DESCRIPTION
The pipeline of previous release fails to release a new version. The error related to a dirty git state, due to a folder called .semrel. From what i can tell this folder is generated in the pipeline and contains the releases that semantic-release will push to git.

This PR adds the folder .semrel to .gitignore.

After some further digging - We are using go-semantic-release to generate semantic releases in this repository. The version we are using is semantic-release@latest. Versions of semantic release > 2.0.0 will place plugins in to a .semrel folder in the working directory. These files are contaminating the git state during the pipeline run, causing the goreleaser step to fail.

See: https://github.com/go-semantic-release/semantic-release